### PR TITLE
baseUrl -> baseURL

### DIFF
--- a/src/kinnosuke.js
+++ b/src/kinnosuke.js
@@ -8,14 +8,14 @@ import TimeSheet from './time_sheet';
 const LOGIN_BUTTON_ID = 'id_passlogin';
 
 export default class Kinnosuke {
-  constructor(companyId, loginId, password, baseUrl = 'https://www.4628.jp') {
+  constructor(companyId, loginId, password, baseURL = 'https://www.4628.jp') {
     this.companyId = companyId;
     this.loginId = loginId;
     this.password = password;
-    this.baseUrl = baseUrl;
+    this.baseURL = baseURL;
     this.cookieJar = new tough.CookieJar();
     this.http = axios.create({
-      baseURL: this.baseUrl,
+      baseURL: this.baseURL,
       jar: this.cookieJar,
       responseType: 'document',
       timeout: 3000,

--- a/src/kinnosuke.test.js
+++ b/src/kinnosuke.test.js
@@ -11,10 +11,10 @@ beforeEach(() => {
   mock = new MockAdapter(client.http);
 });
 
-describe('#baseUrl', () => {
+describe('#baseURL', () => {
   describe('引数を省略したとき', () => {
     test('デフォルト値が設定される', () => {
-      expect(client.baseUrl).toBe('https://www.4628.jp');
+      expect(client.baseURL).toBe('https://www.4628.jp');
     });
   });
 
@@ -24,7 +24,7 @@ describe('#baseUrl', () => {
     });
 
     test('指定した値が設定される', () => {
-      expect(client.baseUrl).toBe('https://example.com');
+      expect(client.baseURL).toBe('https://example.com');
     });
   });
 });


### PR DESCRIPTION
`getElementById`に引っ張られてURLも`Url`としていたけど、頭字語はそのまま大文字のようなので`baseURL`にします。
axiosのbaseURLも大文字だし。

ブラウザAPIで`URL`が使われている例：
https://developer.mozilla.org/ja/docs/Web/API/URL/URL
https://developer.mozilla.org/ja/docs/Web/API/URLSearchParams

idは頭字語じゃなくて略語という判断なのかな