### PR TITLE
TimeRecorderの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
-/node_modules
 npm-debug.log*
+/node_modules
+/coverage

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -165,15 +165,21 @@ function parseTimeRecorder(data) {
   const doc = parseDOM(data);
   const elements = doc.querySelectorAll('#timerecorder_txt');
   const timeRecorder = new TimeRecorder({});
+  const timeRegExp = /\d\d:\d\d/;
 
   // TODO: 外出・戻りのキーワードを確認して実装する
-  // TODO: パースして適切なプロパティにしていく
   for (let element of elements) {
     const text = element.innerHTML;
     if (text.includes('出社')) {
-      timeRecorder.clockIn = text;
+      const result = text.match(timeRegExp);
+      if (result) {
+        timeRecorder.clockIn = result[0];
+      }
     } else if (text.includes('退社')) {
-      timeRecorder.clockOut = text;
+      const result = text.match(timeRegExp);
+      if (result) {
+        timeRecorder.clockOut = result[0];
+      }
     }
   }
 

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -164,30 +164,18 @@ function parseCSRFToken(data) {
 function parseTimeRecorder(data) {
   const doc = parseDOM(data);
   const elements = doc.querySelectorAll('#timerecorder_txt');
-
-  // TODO: 綺麗にしたい
-  const recorder = {
-    clockIn: null,
-    clockOut: null,
-    goOut: null,
-    goBack: null,
-  };
+  const timeRecorder = new TimeRecorder({});
 
   // TODO: 外出・戻りのキーワードを確認して実装する
+  // TODO: パースして適切なプロパティにしていく
   for (let element of elements) {
     const text = element.innerHTML;
     if (text.includes('出社')) {
-      recorder.clockIn = text;
+      timeRecorder.clockIn = text;
     } else if (text.includes('退社')) {
-      recorder.clockOut = text;
+      timeRecorder.clockOut = text;
     }
   }
 
-  // TODO: パースして適切なプロパティにしていく
-  return new TimeRecorder(
-    recorder.clockIn,
-    recorder.clockOut,
-    recorder.goOut,
-    recorder.goBack
-  );
+  return timeRecorder;
 }

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -29,8 +29,8 @@ describe('#getTimeRecorder', () => {
         );
 
       const recorder = await client.getTimeRecorder();
-      expect(recorder.clockIn).toBe('出社<br>(10:00)');
-      expect(recorder.clockOut).toBe('退社<br>(19:00)');
+      expect(recorder.clockIn).toBe('10:00');
+      expect(recorder.clockOut).toBe('19:00');
       expect(recorder.goOut).toBe(null);
       expect(recorder.goBack).toBe(null);
     });
@@ -126,8 +126,8 @@ describe('#_clock', () => {
         );
 
       const recorder = await client._clock(clockOut);
-      expect(recorder.clockIn).toBe('出社<br>(10:00)');
-      expect(recorder.clockOut).toBe('退社<br>(19:00)');
+      expect(recorder.clockIn).toBe('10:00');
+      expect(recorder.clockOut).toBe('19:00');
       expect(recorder.goOut).toBe(null);
       expect(recorder.goBack).toBe(null);
     });

--- a/src/kinnosuke/time_recorder.js
+++ b/src/kinnosuke/time_recorder.js
@@ -1,8 +1,8 @@
 export default class TimeRecorder {
-  constructor(clockIn, clockOut, goOut, goBack) {
-    this.clockIn = clockIn;
-    this.clockOut = clockOut;
-    this.goOut = goOut;
-    this.goBack = goBack;
+  constructor(times) {
+    this.clockIn = times.clockIn || null;
+    this.clockOut = times.clockOut || null;
+    this.goOut = times.goOut || null;
+    this.goBack = times.goBack || null;
   }
 }

--- a/src/kinnosuke/time_recorder.test.js
+++ b/src/kinnosuke/time_recorder.test.js
@@ -3,15 +3,23 @@ import TimeRecorder from './time_recorder';
 let timeRecorder;
 
 beforeEach(() => {
-  timeRecorder = new TimeRecorder('clockIn', 'clockOut', 'goOut', 'goBack');
+  timeRecorder = new TimeRecorder({
+    clockIn: '10:00',
+    clockOut: '19:00',
+    goOut: null,
+    goBack: null,
+  });
 });
 
-// TODO: きちんと実装するときに消す
-describe('#test', () => {
-  test('test', () => {
-    expect(timeRecorder.clockIn).toBe('clockIn');
-    expect(timeRecorder.clockOut).toBe('clockOut');
-    expect(timeRecorder.goOut).toBe('goOut');
-    expect(timeRecorder.goBack).toBe('goBack');
+describe('#constructor', () => {
+  describe('空のオブジェクトを渡したとき', () => {
+    test('打刻時刻がすべてnullのTimeRecorderを返す', () => {
+      timeRecorder = new TimeRecorder({});
+
+      expect(timeRecorder.clockIn).toBe(null);
+      expect(timeRecorder.clockOut).toBe(null);
+      expect(timeRecorder.goOut).toBe(null);
+      expect(timeRecorder.goBack).toBe(null);
+    });
   });
 });

--- a/src/kinnosuke/time_recorder.test.js
+++ b/src/kinnosuke/time_recorder.test.js
@@ -16,10 +16,10 @@ describe('#constructor', () => {
     test('打刻時刻がすべてnullのTimeRecorderを返す', () => {
       timeRecorder = new TimeRecorder({});
 
-      expect(timeRecorder.clockIn).toBe(null);
-      expect(timeRecorder.clockOut).toBe(null);
-      expect(timeRecorder.goOut).toBe(null);
-      expect(timeRecorder.goBack).toBe(null);
+      expect(timeRecorder.clockIn).toBeNull();
+      expect(timeRecorder.clockOut).toBeNull();
+      expect(timeRecorder.goOut).toBeNull();
+      expect(timeRecorder.goBack).toBeNull();
     });
   });
 });


### PR DESCRIPTION
打刻した時刻をパースしていい感じのプロパティにして返すようにします。

時刻はDateにしてもいいけど、

- JSのDateはフォーマット系のメソッドをもっていないので取り回しが不便
- 打刻は分単位で秒切り捨てなので厳密な「時刻」ではない
- 勤之助に日付情報がないので0時を回って打刻したときに不正確な日付になりそう

ということで、単に文字列でもたせることにしました。
出社時刻から9時間たったら通知出す、みたいなことやりたいけど、そのときにDateにするか文字列のままうまく計算するか考える