### PR TITLE
プライベートメソッド・プロパティにアンダースコアをつける

### DIFF
--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -154,7 +154,7 @@ export default class Kinnosuke {
   }
 
   async login() {
-    const response = await this.http.post('/', this.loginParams());
+    const response = await this.http.post('/', this._loginParams());
 
     if (response.data.includes(LOGIN_BUTTON)) {
       return Promise.reject(new Error('Incorrect login id or password'));
@@ -163,7 +163,7 @@ export default class Kinnosuke {
     return response;
   }
 
-  loginParams() {
+  _loginParams() {
     const params = new URLSearchParams({
       module: 'login',
       y_companycd: this.companyId,

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -18,14 +18,14 @@ export default class Kinnosuke {
     this.companyId = companyId;
     this.loginId = loginId;
     this.password = password;
-    this.http = axios.create({
+    this._http = axios.create({
       baseURL: baseURL,
       jar: new tough.CookieJar(),
       responseType: 'document',
       timeout: 3000,
       withCredentials: true,
     });
-    axiosCookieJarSupport(this.http);
+    axiosCookieJarSupport(this._http);
   }
 
   async clockIn() {
@@ -73,7 +73,7 @@ export default class Kinnosuke {
       return Promise.reject(new Error('CSRF token not found'));
     }
 
-    const response = await this.http.post(
+    const response = await this._http.post(
       '/',
       this._clockParams(clockType, csrfToken)
     );
@@ -139,11 +139,11 @@ export default class Kinnosuke {
   }
 
   async _getWithLogin(path) {
-    const firstTry = await this.http.get(path);
+    const firstTry = await this._http.get(path);
 
     if (firstTry.data.includes(LOGIN_BUTTON)) {
       await this._login();
-      const retry = await this.http.get(path);
+      const retry = await this._http.get(path);
 
       return retry;
     }
@@ -152,7 +152,7 @@ export default class Kinnosuke {
   }
 
   async _login() {
-    const response = await this.http.post('/', this._loginParams());
+    const response = await this._http.post('/', this._loginParams());
 
     if (response.data.includes(LOGIN_BUTTON)) {
       return Promise.reject(new Error('Incorrect login id or password'));

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -18,9 +18,8 @@ export default class Kinnosuke {
     this.companyId = companyId;
     this.loginId = loginId;
     this.password = password;
-    this.baseURL = baseURL;
     this.http = axios.create({
-      baseURL: this.baseURL,
+      baseURL: baseURL,
       jar: new tough.CookieJar(),
       responseType: 'document',
       timeout: 3000,

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -31,22 +31,22 @@ export default class Kinnosuke {
   }
 
   async clockIn() {
-    return await this.clock(CLOCK_IN);
+    return await this._clock(CLOCK_IN);
   }
 
   async clockOut() {
-    return await this.clock(CLOCK_OUT);
+    return await this._clock(CLOCK_OUT);
   }
 
   async goOut() {
-    return await this.clock(GO_OUT);
+    return await this._clock(GO_OUT);
   }
 
   async goBack() {
-    return await this.clock(GO_BACK);
+    return await this._clock(GO_BACK);
   }
 
-  async clock(clockType) {
+  async _clock(clockType) {
     const clockPage = await this.login();
 
     if (clockPage.data.includes(IP_ADDRESS_RESTRICTION)) {

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -60,7 +60,7 @@ export default class Kinnosuke {
 
     const response = await this.http.post(
       '/',
-      this.clockParams(clockType, csrfToken)
+      this._clockParams(clockType, csrfToken)
     );
 
     const doc = parseDOM(response.data);
@@ -174,7 +174,7 @@ export default class Kinnosuke {
     return params.toString();
   }
 
-  clockParams(clockType, csrfToken) {
+  _clockParams(clockType, csrfToken) {
     const params = new URLSearchParams({
       module: 'timerecorder',
       action: 'timerecorder',

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -46,6 +46,23 @@ export default class Kinnosuke {
     return await this._clock(GO_BACK);
   }
 
+  async getTimeSheet() {
+    const response = await this._getWithLogin(
+      '/?module=timesheet&action=browse'
+    );
+    const doc = parseDOM(response.data);
+    // TODO: querySelector使う
+    const dailyList = doc.getElementById('submit_form0');
+    const totalList = doc.getElementById('total_list0');
+
+    if (dailyList && totalList) {
+      // TODO: パースして適切なプロパティにしていく
+      return new TimeSheet(dailyList, totalList);
+    }
+
+    return Promise.reject(new Error('Unexpected element'));
+  }
+
   async _clock(clockType) {
     const clockPage = await this._login();
 
@@ -121,23 +138,6 @@ export default class Kinnosuke {
     }
 
     return Promise.reject(new Error('Failed to clock'));
-  }
-
-  async getTimeSheet() {
-    const response = await this._getWithLogin(
-      '/?module=timesheet&action=browse'
-    );
-    const doc = parseDOM(response.data);
-    // TODO: querySelector使う
-    const dailyList = doc.getElementById('submit_form0');
-    const totalList = doc.getElementById('total_list0');
-
-    if (dailyList && totalList) {
-      // TODO: パースして適切なプロパティにしていく
-      return new TimeSheet(dailyList, totalList);
-    }
-
-    return Promise.reject(new Error('Unexpected element'));
   }
 
   async _getWithLogin(path) {

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -124,7 +124,7 @@ export default class Kinnosuke {
   }
 
   async getTimeSheet() {
-    const response = await this.getWithLogin(
+    const response = await this._getWithLogin(
       '/?module=timesheet&action=browse'
     );
     const doc = parseDOM(response.data);
@@ -140,7 +140,7 @@ export default class Kinnosuke {
     return Promise.reject(new Error('Unexpected element'));
   }
 
-  async getWithLogin(path) {
+  async _getWithLogin(path) {
     const firstTry = await this.http.get(path);
 
     if (firstTry.data.includes(LOGIN_BUTTON)) {

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -19,10 +19,9 @@ export default class Kinnosuke {
     this.loginId = loginId;
     this.password = password;
     this.baseURL = baseURL;
-    this.cookieJar = new tough.CookieJar();
     this.http = axios.create({
       baseURL: this.baseURL,
-      jar: this.cookieJar,
+      jar: new tough.CookieJar(),
       responseType: 'document',
       timeout: 3000,
       withCredentials: true,

--- a/src/kinnosuke/kinnosuke.js
+++ b/src/kinnosuke/kinnosuke.js
@@ -47,7 +47,7 @@ export default class Kinnosuke {
   }
 
   async _clock(clockType) {
-    const clockPage = await this.login();
+    const clockPage = await this._login();
 
     if (clockPage.data.includes(IP_ADDRESS_RESTRICTION)) {
       return Promise.reject(new Error('Unauthorized IP address'));
@@ -144,7 +144,7 @@ export default class Kinnosuke {
     const firstTry = await this.http.get(path);
 
     if (firstTry.data.includes(LOGIN_BUTTON)) {
-      await this.login();
+      await this._login();
       const retry = await this.http.get(path);
 
       return retry;
@@ -153,7 +153,7 @@ export default class Kinnosuke {
     return firstTry;
   }
 
-  async login() {
+  async _login() {
     const response = await this.http.post('/', this._loginParams());
 
     if (response.data.includes(LOGIN_BUTTON)) {

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -268,12 +268,12 @@ describe('#_loginParams', () => {
   });
 });
 
-describe('#clockParams', () => {
+describe('#_clockParams', () => {
   test('打刻に必要なパラメータをapplication/x-www-form-urlencoded形式の文字列で返す', () => {
     const clockType = '1';
     const csrfToken = { key: '__sectag_123456', value: 'abcdef' };
 
-    expect(client.clockParams(clockType, csrfToken)).toBe(
+    expect(client._clockParams(clockType, csrfToken)).toBe(
       'module=timerecorder&action=timerecorder&scrollbody=0&timerecorder_stamping_type=1&__sectag_123456=abcdef'
     );
   });

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -153,7 +153,7 @@ describe('#getTimeSheet', () => {
   });
 });
 
-describe('#getWithLogin', () => {
+describe('#_getWithLogin', () => {
   describe('ログインしていないとき', () => {
     test('ログインした上で指定されたパスのレスポンスを返す', async () => {
       expect.assertions(2);
@@ -177,7 +177,7 @@ describe('#getWithLogin', () => {
           mockHeaders
         );
 
-      const response = await client.getWithLogin(
+      const response = await client._getWithLogin(
         '/?module=timesheet&action=browse'
       );
       expect(response.status).toBe(200);
@@ -196,7 +196,7 @@ describe('#getWithLogin', () => {
           mockHeaders
         );
 
-      const response = await client.getWithLogin(
+      const response = await client._getWithLogin(
         '/?module=timesheet&action=browse'
       );
       expect(response.status).toBe(200);

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -11,24 +11,6 @@ beforeEach(() => {
   mock = new MockAdapter(client.http);
 });
 
-describe('#baseURL', () => {
-  describe('引数を省略したとき', () => {
-    test('デフォルト値が設定される', () => {
-      expect(client.baseURL).toBe('https://www.4628.jp');
-    });
-  });
-
-  describe('引数を指定したとき', () => {
-    beforeEach(() => {
-      client = new Kinnosuke('foo', 'bar', 'p@ssw0rd', 'https://example.com');
-    });
-
-    test('指定した値が設定される', () => {
-      expect(client.baseURL).toBe('https://example.com');
-    });
-  });
-});
-
 describe('#clock', () => {
   const clockOut = '2';
 

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -8,7 +8,7 @@ const mockHeaders = { 'set-cookie': null };
 
 beforeEach(() => {
   client = new Kinnosuke('foo', 'bar', 'p@ssw0rd');
-  mock = new MockAdapter(client.http);
+  mock = new MockAdapter(client._http);
 });
 
 describe('#clock', () => {

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -49,7 +49,7 @@ describe('#clock', () => {
           mockHeaders
         );
 
-      const recorder = await client.clock(clockOut);
+      const recorder = await client._clock(clockOut);
       expect(recorder.clockIn).toBe('出社<br>(10:00)');
       expect(recorder.clockOut).toBe('退社<br>(19:00)');
     });
@@ -66,7 +66,7 @@ describe('#clock', () => {
           mockHeaders
         );
 
-      await client.clock(clockOut).catch(error => {
+      await client._clock(clockOut).catch(error => {
         expect(error.name).toBe('Error');
         expect(error.message).toBe('Unauthorized IP address');
       });
@@ -84,7 +84,7 @@ describe('#clock', () => {
           mockHeaders
         );
 
-      await client.clock(clockOut).catch(error => {
+      await client._clock(clockOut).catch(error => {
         expect(error.name).toBe('Error');
         expect(error.message).toBe('CSRF token not found');
       });
@@ -108,7 +108,7 @@ describe('#clock', () => {
           mockHeaders
         );
 
-      await client.clock(clockOut).catch(error => {
+      await client._clock(clockOut).catch(error => {
         expect(error.name).toBe('Error');
         expect(error.message).toBe('Failed to clock');
       });

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -260,9 +260,9 @@ describe('#login', () => {
   });
 });
 
-describe('#loginParams', () => {
+describe('#_loginParams', () => {
   test('ログインに必要なパラメータをapplication/x-www-form-urlencoded形式の文字列で返す', () => {
-    expect(client.loginParams()).toBe(
+    expect(client._loginParams()).toBe(
       'module=login&y_companycd=foo&y_logincd=bar&password=p%40ssw0rd'
     );
   });

--- a/src/kinnosuke/kinnosuke.test.js
+++ b/src/kinnosuke/kinnosuke.test.js
@@ -217,7 +217,7 @@ describe('#login', () => {
           mockHeaders
         );
 
-      const response = await client.login();
+      const response = await client._login();
       expect(response.status).toBe(200);
       expect(response.data).not.toMatch('id_passlogin');
     });
@@ -234,8 +234,8 @@ describe('#login', () => {
           mockHeaders
         );
 
-      await client.login();
-      const retry = await client.login();
+      await client._login();
+      const retry = await client._login();
       expect(retry.status).toBe(200);
       expect(retry.data).not.toMatch('id_passlogin');
     });
@@ -252,7 +252,7 @@ describe('#login', () => {
           mockHeaders
         );
 
-      await client.login().catch(error => {
+      await client._login().catch(error => {
         expect(error.name).toBe('Error');
         expect(error.message).toBe('Incorrect login id or password');
       });


### PR DESCRIPTION
JavaScriptにはprivateがないので、先頭にアンダースコアをつけてプライベートメソッドとする規約がそれなりに使われているようです。
頑張ってプライベートにする方法もあるようですが、JSだしそこまで頑張らなくていいじゃん（そうしたいならTypeScriptとか使うよね…）ということでアンダースコア規約を採用します。

- CookieJarはaxios.create内で作ればいいことに気づいたので`this.cookieJar`は消した
- this.baseURLはプロパティとしてなくてもいいし、変更してもaxiosには反映されないという落とし穴もあるので消した